### PR TITLE
Upload to the RECAP Archive, also a few other things.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note that some federal district courts -- including those in the Eastern Distric
 Big-Cases uses three main Python scripts to gather docket entries, scrape dockets and tweet the results. This is mostly a vestigate of the fact that the bot was built as an add-on to a larger scraping tool. The scripts run in order, every four minutes:
 
 * **pacer_rss.py** - Scrapes PACER's RSS feeds, matches them against a list of selected cases and stores the results in a MySQL database.
-* **bigcases_scrape_docs.py** - Attempts to scrape documents from PACER based on new matches identified from RSS feeds. It also publishes the results on DocumentCloud. 
+* **bigcases_scrape_docs.py** - Attempts to scrape documents from PACER based on new matches identified from RSS feeds. It also publishes the results on DocumentCloud and the RECAP archive.
 * **bigcases.py** - Tweets the results.
 
 ## Settings and lists of stuff
@@ -20,3 +20,10 @@ The list of cases Big-Cases is following is stored in **bigcases_list.py**; the 
 ## Other stuff to know
 
 Big-Cases has only been tested on a machine running CentOS Linux 7. 
+
+## Dependencies
+
+  pip install python-documentcloud
+
+Customize `bigcases_settings` with credential information for PACER,
+DocumentCloud, Twitter, RECAP, &c.

--- a/bigcases.py
+++ b/bigcases.py
@@ -86,7 +86,7 @@ class caseShare:
 				media_ids = self.twitter_upload(images)
 			
 		elif DP1.search(d):
-			# If the document ahsn't maded it to DC, send the PACER link
+			# If the document hasn't made it to DC, send the PACER link
 			link = DP1.search(d).group(2)
 			nd = DP1.search(d).group(1) + '\n\nDoc. on PACER: ' + link
 		elif DP2.search(d):

--- a/bigcases_scrape_docs.py
+++ b/bigcases_scrape_docs.py
@@ -94,7 +94,7 @@ def getDocument(pid, url):
 	
 	print '   - price: ' + str(price)
 	
-	# Now fetch the document if it's price is less than the max cost
+	# Now fetch the document if its price is less than the max cost
 	if price <= settings.pacer_max_price and price is not None:
 		print '   - extract'
 		#br.find_element_by_xpath("//input[@type='submit']").click()

--- a/bigcases_scrape_docs.py
+++ b/bigcases_scrape_docs.py
@@ -114,7 +114,16 @@ def getDocument(case, url):
 			shutil.move(files[0], newfn)
 			
 			dcid = None
-			dcdoc = dc.documents.upload(newfn, source='U.S. District Court via big_cases bot', project = settings.dc_project_id, access = ACCESS)
+
+			# source isn't publicly visible; description is public & free-form text.
+			dcdoc = dc.documents.upload(
+				newfn,
+				source='U.S. District Court via big_cases bot',
+				description='%s in %s (%s, %s) dated %s from %s' % (
+					case['description]', case['title'], case['case_number'],
+					case['court'], case['pubdate'], case['link']),
+				project = settings.dc_project_id,
+				access = ACCESS)
 			
 			print '   - DocumentCloud: ' + str(dcdoc.id)
 			

--- a/bigcases_scrape_docs.py
+++ b/bigcases_scrape_docs.py
@@ -7,6 +7,7 @@ import time
 
 from bigcases_settings import settings
 from documentcloud import DocumentCloud
+from recapupload import RecapUpload
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.keys import Keys
@@ -141,6 +142,13 @@ def getDocument(case, url):
 						bigcase = 3
 					WHERE pid = %s """,
 					(dcdoc.id, str(dcdoc.published_url), price, pid, ))
+
+                        # While DocumentCloud processes the document, upload it to RECAP
+                        recap = RecapUpload(newfn,
+                                            case['case_number'],
+                                            case['title'],
+                                            case['pubdate'],
+                                            case['description'])
 
 			# Wait until the document is public
 			obj = dc.documents.get(dcdoc.id)

--- a/bigcases_scrape_docs.py
+++ b/bigcases_scrape_docs.py
@@ -1,16 +1,17 @@
-from selenium import webdriver
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.chrome.options import Options
-import re
 import dbconnect
-from documentcloud import DocumentCloud
-import time
-from urlparse import urljoin
 import glob
-import shutil
 import os
-from xvfbwrapper import Xvfb
+import re
+import shutil
+import time
+
 from bigcases_settings import settings
+from documentcloud import DocumentCloud
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.keys import Keys
+from urlparse import urljoin
+from xvfbwrapper import Xvfb
 
 waittime = 10
 

--- a/bigcases_scrape_docs.py
+++ b/bigcases_scrape_docs.py
@@ -52,9 +52,11 @@ def handleLogin():
 	br.find_element_by_name('login:clientCode').send_keys(Keys.RETURN)
 	time.sleep(3)
 	
-def getDocument(pid, url):
+def getDocument(case, url):
 	global waittime
 	global br
+
+	pid = case['pid']
 
 	br.get(url)
 	time.sleep(2)
@@ -171,9 +173,10 @@ if __name__ == '__main__':
 
 						
 			for case in cases:
-				if URL.search(case['description']):
+				url = URL.search(case['description'])
+				if url:
 					print ' - ' + case['title'] + ' (' + case['court'] + ')'
-					getDocument(case['pid'], URL.search(case['description']).group(1))
+					getDocument(case, url.group(1))
 				
 			br.quit()
 			display.stop()

--- a/bigcases_settings.py
+++ b/bigcases_settings.py
@@ -32,3 +32,5 @@ class settings:
 	twitter_oauth_key = ''
 	twitter_oauth_secret = ''
 
+        # RECAP credentials
+        recap_token=''

--- a/recapupload.py
+++ b/recapupload.py
@@ -29,6 +29,7 @@ from bigcases_settings import settings
 
 
 API_BASE = 'https://www.courtlistener.com/api/rest/v3/'
+TIMEOUTS = (60, 300)  # 1 minute connect timeout, 5 min. read timeout
 VERBOSE = 1
 
 
@@ -134,6 +135,7 @@ class RecapUpload(object):
             headers={'Authorization': 'Token %s' % settings.recap_token},
             params={'court': court,
                     'pacer_case_id': pacer_case_id},
+            timeout=TIMEOUTS,
         )
         if VERBOSE >= 2:
             print "Returns:", r, r.text
@@ -173,7 +175,8 @@ class RecapUpload(object):
                 params={
                     'docket': cl_docket_id,
                     'entry_number': entry_number,
-                }
+                },
+                timeout=TIMEOUTS,
             )
             if VERBOSE >= 2:
                 print "Returns: ", r
@@ -235,6 +238,7 @@ class RecapUpload(object):
                     'debug': 'false',  # Server throws away in debug mode
                 },
                 files=files,
+                timeout=TIMEOUTS,
             )
             if VERBOSE >= 2:
                 print "Returns: ", r, r.text
@@ -257,6 +261,7 @@ class RecapUpload(object):
                 'debug': 'false',  # Server throws away in debug mode
             },
             files=files,
+            timeout=TIMEOUTS,
         )
         if VERBOSE > 0:
             print "RECAP upload returns: ", r, r.text

--- a/recapupload.py
+++ b/recapupload.py
@@ -1,0 +1,264 @@
+# Upload a PDF to the RECAP Archive.
+#
+# John Hawkinson <jhawk@mit.edu>
+# 29 December 2017
+#
+# This is kind of rough, because:
+#
+# * RECAP/CourtListener (CL) wants PACER metadata for each PDF BEFORE
+#   it receives the PDF
+# * BigCases doesn't preserve the exact RSS XML so we can't just feed
+#   it to RECAP
+# * RECAP doesn't have an RSS XML-input endpoint, although it could
+#   easily gain one
+# * So before we can upload a PDF, we have to fake up the metadata in
+#   the format that CL understands, and transmit it. But only if that
+#   metadata isn't already there.
+# * Because BigCases doesn't preserve the parsed data from the RSS
+#   feed, we need to use feedparser's date parser to get it.
+
+from HTMLParser import HTMLParser
+
+import feedparser
+import re
+import requests
+import time
+import urlparse
+
+from bigcases_settings import settings
+
+
+API_BASE = 'https://www.courtlistener.com/api/rest/v3/'
+VERBOSE = 2
+
+
+class RecapUpload(object):
+    """Upload a document to the RECAP archive."""
+
+    def pacerCourtToCL(self, pacerCourt):
+        # An unfortunate design decision was made in the past.
+        PACER_TO_CL_IDS = {
+            'azb': 'arb',         # Arizona Bankruptcy Court
+            'cofc': 'uscfc',      # Court of Federal Claims
+            'neb': 'nebraskab',   # Nebraska Bankruptcy
+            'nysb-mega': 'nysb',   # Remove the mega thing
+        }
+
+        return PACER_TO_CL_IDS.get(pacerCourt, pacerCourt)
+
+    def __init__(self, filename,
+                 docketNumber, docketCaption,
+                 publishedDate,
+                 itemDescription):
+        """Upload a document to the RECAP archive.
+
+        We do based on what little information we have. This involves
+        multiple roundtrips to the RECAP server, unfortunately.
+
+        The parameters we get are all from RSS, as available to the
+        BigCases scraper. Unfortunately that's not the full RSS XML,
+        because it takes a trip through a SQL database.
+
+        PARAMETER: SOURCE
+          docketNumber and docketCaption:        item.title
+          publishedDate:                         item.published
+          itemDescription:                       item.description
+
+        Outline:
+        1. We first parse the itemDescription to get the docket text,
+           the item URL (including DLS aka "doc1" number), and the
+           entry number (link anchor).
+        2. We lookup the case, or determine we need to fake it.
+        3. We lookup the docket entry, or determine we need to fake it.
+        4. If necessary, we fake the docket entry and case title.
+        5. We upload the PDF.
+        """
+
+        if not len(settings.recap_token) >= 40:
+            # Not a valid token
+            return None
+
+        # #1. We first parse the itemDescription to get the docket text,
+
+        h = HTMLParser()
+        itemDecoded = h.unescape(itemDescription)
+# BEFORE unescape() call:
+# [Motion For Order] (<a href="https://ecf.dcd.uscourts.gov/
+# doc1/04506366063?caseid=190182&amp;de_seq_num=369">94</a>)
+# AFTER unescape() call:
+# [Motion For Order] (<a href="https://ecf.dcd.uscourts.gov/
+# doc1/04506366063?caseid=190182&de_seq_num=369">94</a>)
+
+# NOTE that Appellate takes this form:
+# [Order Filed (CLERK)] (<a href='https://ecf.cadc.uscourts.gov/
+# docs1/01207988480'>Document</a>)
+
+        match = re.search(r'''(?x)
+            \[(?P<text>[^\]]*)\]
+            .*?
+            <a\ href=(?P<q1>["'])(?P<url>.*?)(?P=q1)\s*>
+            (?P<anchor>.*?)
+            </a>
+        ''', itemDecoded)
+        if match is None:
+            return None
+
+        text = match.group('text')
+        url = match.group('url')
+        entry_number = match.group('anchor')
+
+        match = re.search(r'http.*/docs?1/(?P<dls>\d+)\?', url)
+        pacer_doc_id = match.group('dls')
+        if pacer_doc_id[3:4] == '1':
+            # PACER sites use the fourth digit of the pacer_doc_id to
+            # flag whether the user has been shown a receipt page.  We
+            # don't care about that, so we always set the fourth digit
+            # to 0 when getting a doc ID.
+            pacer_doc_id = pacer_doc_id[0:3] + '0' + pacer_doc_id[4:]
+
+        parsedUrl = urlparse.urlparse(url)
+        court = self.pacerCourtToCL(parsedUrl.hostname.split('.')[1])
+        qparams = urlparse.parse_qs(parsedUrl.query)
+
+        pacer_case_id = qparams['caseid'][0]
+
+        # #2. We lookup the case, or determine we need to fake it.
+
+        needFakeCase = False
+        needFakeEntry = False
+        if VERBOSE > 0:
+            print "Checking RECAP for case %s in %s" % (pacer_case_id, court)
+        # /dockets/?pacer_case_id=189311&court=mad
+        r = requests.get(
+            url=API_BASE+'dockets/',
+            headers={'Authorization': 'Token %s' % settings.recap_token},
+            params={'court': court,
+                    'pacer_case_id': pacer_case_id},
+        )
+        if VERBOSE >= 2:
+            print "Returns:", r, r.text
+        rj = r.json()
+
+        if (not r.ok) or rj['count'] < 1:
+            if VERBOSE > 0:
+                print "RECAP docket doesn't exist. We need to fake one up."
+            needFakeCase = True
+        else:
+            # The CL docket ID, needed for the next query, is here:
+            # "resource_uri":
+            # "https://www.courtlistener.com/api/rest/v3/dockets/6125037/",
+            cl_docket_id = re.search(r'/dockets/(\d+)/',
+                                     rj['results'][0]['resource_uri']).group(1)
+
+        # #3. We lookup the docket entry, or determine we need to fake it.
+        if not needFakeCase:
+            # If we don't have a case, we need not check for a docket entry
+            if VERBOSE > 0:
+                print "Checking RECAP for entry %s in CL case %s" \
+                    % (entry_number, cl_docket_id)
+            # Originally we had:
+            #   /recap-documents/?pacer_case_id=189311&court=mad
+            #     &pacer_doc_id=09508417779
+            # Or simply
+            #   /recap-documents/?pacer_doc_id=09508417779
+            # But alternatively
+            #   /docket-entries/?recap_documents__pacer_doc_id=09508346951
+            # But now Mike's preference:
+            #   /docket-entries/?docket_id=6249495&entry_number=13
+            # Because in some corner cases there is a Docket Entry
+            # object without a RECAP docket (...)
+            r = requests.get(
+                url=API_BASE+'docket-entries/',
+                headers={'Authorization': 'Token %s' % settings.recap_token},
+                params={
+                    'docket': cl_docket_id,
+                    'entry_number': entry_number,
+                }
+            )
+            if VERBOSE >= 2:
+                print "Returns: ", r
+            rj = r.json()
+            # Control debugging spew.
+            # plain_text is a very large amount of text.
+            try:
+                plainText = \
+                    rj['results'][0]['recap_documents'][0]['plain_text']
+                if len(plainText) > 80:
+                    rj['results'][0]['recap_documents'][0]['plain_text'] = \
+                        plainText.strip()[:40] + '...'
+            except IndexError:
+                pass
+            if VERBOSE >= 2:
+                print rj
+
+            if (not r.ok) or rj['count'] < 1:
+                if VERBOSE > 0:
+                    print "The docket ENTRY doesn't exist. " + \
+                        "We need to fake one up."
+                needFakeEntry = True
+
+        # #4. If necessary, we fake the docket entry and case title.
+        if needFakeCase or needFakeEntry:
+            # Either because of the case docket or the docket entry's absence
+            # we must fake up a docket.
+            date = time.strftime('%m/%d/%Y',
+                                 feedparser._parse_date(publishedDate))
+            html = ''
+            html += '<h3>THIS IS A FAKED UP DOCKET VIA RSS THROUGH '
+            html += 'recapupload.py<br>\n'
+            html += '%s</h3>\n' % docketNumber
+            html += '<table>'
+            if needFakeCase:
+                html += '<td><br>%s' % docketCaption
+            # Lack of whitespace after this colon matters!
+            html += '<td>Date Filed:</table>\n'
+            html += '<table>'
+            html += '<tr>'
+            html += '<td>Date Filed</td><th>#</th><td>Docket Text</td></tr>\n'
+            html += '<tr>'
+            html += '<td>%s</td>\n' % date
+            html += '<td><a href="%s">%s</td>\n' % (url, entry_number)
+            html += '<td>%s</td>' % text
+            html += '</tr>\n</tbody></table>\n'
+
+            if VERBOSE >= 2:
+                print "We faked up this: \n", html
+
+            files = {'filepath_local': ('filepath_local', html, 'text/html')}
+            r = requests.post(
+                url=API_BASE+'recap/',
+                headers={'Authorization': 'Token %s' % settings.recap_token},
+                data={
+                    'upload_type': '1',
+                    'court': court,
+                    'pacer_case_id': pacer_case_id,
+                    'debug': 'false',  # Server throws away in debug mode
+                },
+                files=files,
+            )
+            if VERBOSE >= 2:
+                print "Returns: ", r, r.text
+            if (not r.ok):
+                if VERBOSE > 0:
+                    print "Failed to upload faked docket entry info to RECAP."
+                return None
+
+        # #5. We upload the PDF.
+        files = {'filepath_local': open(filename, 'rb')}
+        r = requests.post(
+            url=API_BASE+'recap/',
+            headers={'Authorization': 'Token %s' % settings.recap_token},
+            data={
+                'upload_type': '3',
+                'court': court,
+                'pacer_case_id': pacer_case_id,
+                'pacer_doc_id': pacer_doc_id,
+                'document_number': entry_number,
+                'debug': 'false',  # Server throws away in debug mode
+            },
+            files=files,
+        )
+        if VERBOSE > 0:
+            print "RECAP upload returns: ", r, r.text
+
+        return None

--- a/recapupload.py
+++ b/recapupload.py
@@ -29,7 +29,7 @@ from bigcases_settings import settings
 
 
 API_BASE = 'https://www.courtlistener.com/api/rest/v3/'
-VERBOSE = 2
+VERBOSE = 1
 
 
 class RecapUpload(object):

--- a/recapupload.py
+++ b/recapupload.py
@@ -42,7 +42,7 @@ class RecapUpload(object):
             'azb': 'arb',         # Arizona Bankruptcy Court
             'cofc': 'uscfc',      # Court of Federal Claims
             'neb': 'nebraskab',   # Nebraska Bankruptcy
-            'nysb-mega': 'nysb',   # Remove the mega thing
+            'nysb-mega': 'nysb',  # Remove the mega thing
         }
 
         return PACER_TO_CL_IDS.get(pacerCourt, pacerCourt)

--- a/recapupload.py
+++ b/recapupload.py
@@ -33,6 +33,15 @@ TIMEOUTS = (60, 300)  # 1 minute connect timeout, 5 min. read timeout
 VERBOSE = 1
 
 
+class _UploadType():
+    DOCKET = 1
+    ATTACHMENT_PAGE = 2
+    PDF = 3
+    DOCKET_HISTORY_REPORT = 4
+    APPELLATE_DOCKET = 5
+    APPELLATE_ATTACHMENT_PAGE = 6
+
+
 class RecapUpload(object):
     """Upload a document to the RECAP archive."""
 
@@ -232,7 +241,7 @@ class RecapUpload(object):
                 url=API_BASE+'recap/',
                 headers={'Authorization': 'Token %s' % settings.recap_token},
                 data={
-                    'upload_type': '1',
+                    'upload_type': _UploadType.DOCKET,
                     'court': court,
                     'pacer_case_id': pacer_case_id,
                     'debug': 'false',  # Server throws away in debug mode
@@ -253,7 +262,7 @@ class RecapUpload(object):
             url=API_BASE+'recap/',
             headers={'Authorization': 'Token %s' % settings.recap_token},
             data={
-                'upload_type': '3',
+                'upload_type': _UploadType.PDF,
                 'court': court,
                 'pacer_case_id': pacer_case_id,
                 'pacer_doc_id': pacer_doc_id,


### PR DESCRIPTION
I spent a while this week addressing some low-hanging fruit in Big Cases.
The bulk of this patch is support for uploading to the RECAP Archive.
It's from me with a little bit of help from @mlissner.

Note that this requires authorization. @bdheath , your personal CL API token should be enabled (add to `bigcases_setings.py`), although you should probably register a separate one for the bot and use that.

This also brings along for the ride the metadata that Aaron asked for recently on Twitter in this thread https://twitter.com/johnhawkinson/status/946201604461678595.

I don't have the whole Big Cases infrastructure running, so the changes there are untested. But the `recapupload.py` code has been decently well-tested (with an out-of-tree driver),  and the changes to add it are minimal.

And then some typo fixes.
I made no attempt to conform the existing code to PEP-8, although `recapupload.py` complies.

There are some design choices in Big Cases that made this trickier.
It would be nice to just upload the raw RSS XML to RECAP, except that's not saved in the database. (Also RECAP doesn't have an endpoint to receive it, but that could be arranged. Indeed, Mike would prefer to do it that way, but I convinced him that this way was the speediest. But a future rev could use that. Such an endpoint would reduce the roundtrips.) It can be partially reconstituted from the fields in the Big Cases database, though. 

Also, it would have been nice if Big Cases could save the parsed datestamps instead of the raw RSS/XML datestamps, so this code doesn't need to know about RSS time formats (`import feedparser`). Oh well.

This code doesn't make any attempt to deal with the case of merged attachments. That's probably worthy of some attention.

I think there's something else I'm forgetting but I'll add it in later if so.